### PR TITLE
Enable OSX as supported system

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
-      }
-    },
-    "utils": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,23 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -19,36 +19,36 @@
 
     in
 
-  {
+    {
 
-    overlay = final: prev: {};
+      overlay = final: prev: { };
 
-    apps = forAllSystems (system:
-      let
-        pkgs = nixpkgsFor."${system}";
-      in
-      {
-        lint-haskell = {
-          type = "app";
-          program = "${self.linters.${system}.haskell.lintScript}/bin/lint";
-        };
-      });
+      apps = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor."${system}";
+        in
+        {
+          lint-haskell = {
+            type = "app";
+            program = "${self.linters.${system}.haskell.lintScript}/bin/lint";
+          };
+        });
 
-    linters = forAllSystems (system:
-      let
-        pkgs = nixpkgsFor."${system}";
-      in
-      {
-        haskell = import ./linters/haskell.nix { inherit pkgs; };
-      });
+      linters = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor."${system}";
+        in
+        {
+          haskell = import ./linters/haskell.nix { inherit pkgs; };
+        });
 
-    internal = forAllSystems (system:
-      let
-        pkgs = nixpkgsFor."${system}";
-      in
-      {
-        mkDoc = import ./internal/mkdoc.nix { inherit pkgs; };
-      });
-  };
+      internal = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor."${system}";
+        in
+        {
+          mkDoc = import ./internal/mkdoc.nix { inherit pkgs; };
+        });
+    };
 
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,21 +1,22 @@
 {
   # Nixpkgs / NixOS version to use.
-  inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
-    utils.url = "github:numtide/flake-utils";
-  };
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
 
-  outputs = { self, nixpkgs, utils }:
+  outputs = { self, nixpkgs }:
     let
 
       # Generate a user-friendly version number.
       version = builtins.substring 0 8 self.lastModifiedDate;
 
       # System types to support.
-      supportedSystems = utils.lib.defaultSystems;
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+      ];
 
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
-      forAllSystems = utils.lib.eachSystemMap supportedSystems;
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
       # Nixpkgs instantiated for supported system types.
       nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; overlays = [ self.overlay ]; });

--- a/flake.nix
+++ b/flake.nix
@@ -1,18 +1,21 @@
 {
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
+    utils.url = "github:numtide/flake-utils";
+  };
 
-  outputs = { self, nixpkgs }:
+  outputs = { self, nixpkgs, utils }:
     let
 
       # Generate a user-friendly version number.
       version = builtins.substring 0 8 self.lastModifiedDate;
 
       # System types to support.
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      supportedSystems = utils.lib.defaultSystems;
 
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      forAllSystems = utils.lib.eachSystemMap supportedSystems;
 
       # Nixpkgs instantiated for supported system types.
       nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; overlays = [ self.overlay ]; });


### PR DESCRIPTION
Please note that the *first* commit is formatting the flake using `nixpkgs-fmt`. If you don't agree with this format, please let me know, I will revert that change and apply it to the format that was already here. I don't see we use any formatter for nix files and I thought it might be a first good step. But as mentioned, this is a separate commit.

In this PR we've added dependency on flake-utils which provides:
* `defaultSystems` list which holds both Linux and OSX on aarch64 and x86_64
* `eachSystemMap` which does the same thing as `genAttrs` but a bit differently
  Which is better is debatable, both are good IMHO. Nix folks on the webs are
  using `flake-utils` functions, so I've chosen to follow the herd.