### PR TITLE
Add Hercules-CI

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -1,0 +1,3 @@
+if builtins?getFlake
+then (builtins.getFlake (toString ./.)).ciNix
+else (import ./flake-compat.nix).defaultNix.ciNix

--- a/flake-compat.nix
+++ b/flake-compat.nix
@@ -1,0 +1,9 @@
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  inherit (lock.nodes.flake-compat.locked) owner repo rev narHash;
+  flake-compat = builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  };
+in
+import flake-compat { src = ./.; }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,36 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat-ci": {
+      "locked": {
+        "lastModified": 1646664117,
+        "narHash": "sha256-AX2VewPcS9eRsoirVHfnk07MHAOH6CTDiD10XtRaZbk=",
+        "owner": "hercules-ci",
+        "repo": "flake-compat-ci",
+        "rev": "e588637b2eec4261ed0d36335c83a117f2744dea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-compat-ci",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1639161226,
@@ -18,6 +49,8 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-compat-ci": "flake-compat-ci",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,15 @@
 {
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
+    flake-compat-ci.url = "github:hercules-ci/flake-compat-ci";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
 
-  outputs = { self, nixpkgs }:
+  outputs = { self, nixpkgs, flake-compat, flake-compat-ci }:
     let
 
       # Generate a user-friendly version number.
@@ -20,6 +27,11 @@
     in
 
   {
+
+    ciNix = flake-compat-ci.lib.recurseIntoFlakeWith {
+      flake = self;
+      systems = [ "x86_64-linux" ];
+    };
 
     overlay = final: prev: {};
 


### PR DESCRIPTION
Adds Hercules-Ci to this repository, which makes use of the new flake-compat evaluator https://github.com/hercules-ci/flake-compat-ci/pull/5 to catch string context errors, which was added thanks to the discussion in https://github.com/ArdanaLabs/danalib/pull/7