### PR TITLE
cleaning up flake and providing CI update

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -1,3 +1,0 @@
-if builtins?getFlake
-then (builtins.getFlake (toString ./.)).ciNix
-else (import ./flake-compat.nix).defaultNix.ciNix

--- a/flake-compat.nix
+++ b/flake-compat.nix
@@ -1,9 +1,0 @@
-let
-  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-  inherit (lock.nodes.flake-compat.locked) owner repo rev narHash;
-  flake-compat = builtins.fetchTarball {
-    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
-    sha256 = narHash;
-  };
-in
-import flake-compat { src = ./.; }

--- a/flake.lock
+++ b/flake.lock
@@ -1,36 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat-ci": {
-      "locked": {
-        "lastModified": 1646664117,
-        "narHash": "sha256-AX2VewPcS9eRsoirVHfnk07MHAOH6CTDiD10XtRaZbk=",
-        "owner": "hercules-ci",
-        "repo": "flake-compat-ci",
-        "rev": "e588637b2eec4261ed0d36335c83a117f2744dea",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-compat-ci",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1639161226,
@@ -49,8 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-compat-ci": "flake-compat-ci",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,14 +2,9 @@
   # Nixpkgs / NixOS version to use.
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
-    flake-compat-ci.url = "github:hercules-ci/flake-compat-ci";
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
   };
 
-  outputs = { self, nixpkgs, flake-compat, flake-compat-ci }:
+  outputs = { self, nixpkgs }:
     let
 
       # Generate a user-friendly version number.
@@ -25,14 +20,7 @@
       nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; overlays = [ self.overlay ]; });
 
     in
-
   {
-
-    ciNix = flake-compat-ci.lib.recurseIntoFlakeWith {
-      flake = self;
-      systems = [ "x86_64-linux" ];
-    };
-
     overlay = final: prev: {};
 
     apps = forAllSystems (system:
@@ -59,8 +47,10 @@
         pkgs = nixpkgsFor."${system}";
       in
       {
-        mkDoc = import ./internal/mkdoc.nix { inherit pkgs; };
+        mkDoc = import ./internal/mkdoc.nix {  inherit pkgs; };
       });
+
+      herculesCI.ciSystems = [ "x86_64-linux" ];
   };
 
 }


### PR DESCRIPTION
As our instance of Hercules has been updated, we no longer require the ci-compat shim to build using flakes.

Given native support of our functional pipeline, I am removing the ci-compat throughout our repositories.
