### PR TITLE
Introduce extraLatexPackages argument

### DIFF
--- a/internal/mkdoc.nix
+++ b/internal/mkdoc.nix
@@ -6,9 +6,12 @@
    mkDoc assumes that the LaTeX source file can be compiled using
    a standardized set of dependencies.
 */
-name: src: inFile: outFile:
+{name, src, inFile, outFile, extraLatexPackages ? {}}:
   with pkgs;
-  let deps = [ (texlive.combine { inherit (texlive) scheme-basic amsmath graphics hyperref pgf; }) ];
+  let
+    defaultLatexPackages = { inherit (texlive) scheme-basic amsmath graphics hyperref pgf; };
+    deps = [ (texlive.combine (lib.trivial.mergeAttrs defaultLatexPackages extraLatexPackages))
+           ];
   in
     stdenv.mkDerivation {
       name = name;


### PR DESCRIPTION
In this commit we are introducing a new argument to a mkDoc function called
extraLatexPackages. This is an attribute set holding additional latex packages
that are not included in the texlive build dependency by default.

This allows projects that are using mkDoc to add additional LaTeX packages that
they need, without polluting the danalib/mkDoc.

Because this argument has a natural default value (an empty attribute set),
we've modified the definition of mkDoc to take a single attribute set as an
argument. Therefore this is not a completely backward-compatible change - the
projects that are using mkDoc will have to modify their function calls. 

Bellow example how the `Orbis/whitepaper` will have to be modified:

```diff
     packages.x86_64-linux.orbis-whitepaper =
-      danalib.internal.x86_64-linux.mkDoc
-      "orbis-whitepaper"
-      ./src
-      "whitepaper"
-      "Orbis Technical Whitepaper";
+     danalib.internal.x86_64-linux.mkDoc {
+      name = "orbis-whitepaper";
+      src = ./src;
+      inFile = "whitepaper";
+      outFile = "Orbis Technical Whitepaper";
+   };
```


